### PR TITLE
Ensure that AWS inputs are masked as secrets

### DIFF
--- a/__mocks__/@actions/core.ts
+++ b/__mocks__/@actions/core.ts
@@ -1,3 +1,4 @@
 export const setFailed = jest.fn();
 export const getInput = jest.fn();
 export const setOutput = jest.fn();
+export const setSecret = jest.fn();

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import AWS from 'aws-sdk/global';
 import { main, Props, Credentials, ExtraOptions } from '../src';
-import { setFailed, getInput, setOutput } from '../__mocks__/@actions/core';
+import { setFailed, getInput, setOutput, setSecret } from '../__mocks__/@actions/core';
 import Lambda, { constructorMock } from '../__mocks__/aws-sdk/clients/lambda';
 
 describe('invoke-aws-lambda', () => {
@@ -29,6 +29,7 @@ describe('invoke-aws-lambda', () => {
     getInput.mockClear();
     setFailed.mockClear();
     setOutput.mockClear();
+    setSecret.mockClear();
   });
 
   it('runs when provided the correct input', async () => {
@@ -39,6 +40,7 @@ describe('invoke-aws-lambda', () => {
     await main();
     expect(getInput).toHaveBeenCalledTimes(13);
     expect(setFailed).not.toHaveBeenCalled();
+    expect(setSecret).toHaveBeenCalledTimes(2);
     expect(AWS.config.httpOptions).toMatchInlineSnapshot(`
       Object {
         "timeout": 220000,
@@ -95,6 +97,7 @@ describe('invoke-aws-lambda', () => {
     `);
     expect(setFailed).toHaveBeenCalled();
     expect(setOutput).not.toHaveBeenCalled();
+    expect(setSecret).toHaveBeenCalledTimes(2);
   });
 
   describe('when the function returns an error', () => {
@@ -122,6 +125,7 @@ describe('invoke-aws-lambda', () => {
 
       expect(setOutput).toHaveBeenCalled();
       expect(setFailed).toHaveBeenCalled();
+      expect(setSecret).toHaveBeenCalledTimes(2);
     });
 
     it('should fail the action when SUCCEED_ON_FUNCTION_FAILURE is false', async () => {
@@ -140,6 +144,7 @@ describe('invoke-aws-lambda', () => {
 
       expect(setOutput).toHaveBeenCalled();
       expect(setFailed).toHaveBeenCalled();
+      expect(setSecret).toHaveBeenCalledTimes(2);
     });
 
     it('should succeed the action when SUCCEED_ON_FUNCTION_FAILURE is true', async () => {
@@ -158,6 +163,7 @@ describe('invoke-aws-lambda', () => {
 
       expect(setOutput).toHaveBeenCalled();
       expect(setFailed).not.toHaveBeenCalled();
+      expect(setSecret).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -165,5 +165,28 @@ describe('invoke-aws-lambda', () => {
       expect(setFailed).not.toHaveBeenCalled();
       expect(setSecret).toHaveBeenCalledTimes(2);
     });
+
+    it("should call setSecret on AWS_SESSION_TOKEN when it's provided", async () => {
+      const overriddenMockedInput = {
+        ...mockedInput,
+        [Credentials.AWS_SESSION_TOKEN]: 'someSessionToken',
+      };
+
+      getInput.mockImplementation(
+        (key: Partial<Props & Credentials & 'REGION'>) => {
+          return overriddenMockedInput[key];
+        }
+      );
+
+      const handler = jest.fn(() => ({ response: 'ok' }));
+
+      Lambda.__setResponseForMethods({ invoke: handler });
+
+      await main();
+
+      expect(getInput).toHaveBeenCalledTimes(13);
+      expect(setFailed).not.toHaveBeenCalled();
+      expect(setSecret).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import AWS from 'aws-sdk/global';
 import Lambda from 'aws-sdk/clients/lambda';
-import { getInput, setOutput, setFailed } from '@actions/core';
+import { getInput, setOutput, setFailed, setSecret } from '@actions/core';
 
 const apiVersion = '2015-03-31';
 
@@ -26,10 +26,22 @@ export enum Props {
 }
 
 const setAWSCredentials = () => {
+  const accessKeyId = getInput(Credentials.AWS_ACCESS_KEY_ID);
+  setSecret(accessKeyId);
+
+  const secretAccessKey = getInput(Credentials.AWS_SECRET_ACCESS_KEY);
+  setSecret(secretAccessKey);
+
+  const sessionToken = getInput(Credentials.AWS_SESSION_TOKEN);
+  // Make sure we only mask if specified
+  if (sessionToken) {
+    setSecret(sessionToken);
+  }
+
   AWS.config.credentials = {
-    accessKeyId: getInput(Credentials.AWS_ACCESS_KEY_ID),
-    secretAccessKey: getInput(Credentials.AWS_SECRET_ACCESS_KEY),
-    sessionToken: getInput(Credentials.AWS_SESSION_TOKEN),
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
   };
 };
 


### PR DESCRIPTION
Using `setSecret` on the value of the secret provided as an input ensures that GitHub's runner will mask the value anywhere it shows up in logs.

Fixes https://github.com/gagoar/invoke-aws-lambda/issues/219

References:
* [`setSecret` docs](https://github.com/actions/toolkit/tree/main/packages/core#setting-a-secret)