### PR TITLE
fixing deprecation warning for testURL -> testEnvironmentOptions.url

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,19 +3,21 @@ process.env.TZ = 'UTC';
 module.exports = {
   globals: {
     'ts-jest': {
-      disableSourceMapSupport: true
-    }
+      disableSourceMapSupport: true,
+    },
   },
   verbose: true,
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testEnvironmentOptions: {
+    url: 'http://localhost',
   },
   preset: 'ts-jest',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testURL: 'http://localhost',
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
   testMatch: ['**/*.spec.ts'],
   collectCoverage: true,
   collectCoverageFrom: ['src/*.ts', '!./index.ts'],
-  coverageDirectory: './coverage/'
+  coverageDirectory: './coverage/',
 };


### PR DESCRIPTION
addressing 
```bash
● Deprecation Warning:

  Option "testURL" was replaced by passing the URL via "testEnvironmentOptions.url".

  Please update your configuration.

  Configuration Documentation:
  https://jestjs.io/docs/configuration
  ```
This was introduced by the latest updates on jest and ts-jest. 