### PR TITLE
Update action runime to node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,5 @@ outputs:
   response: # id of output
     description: "response from lambda invocation"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
Github announced deprecation of node v12 runtime.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

So this PR changes`action.yml` to update runtime to node v16.
([.nvmrc](https://github.com/gagoar/invoke-aws-lambda/blob/master/.nvmrc) is already node16)