### PR TITLE
Update action runime to node v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,5 @@ outputs:
   response: # id of output
     description: "response from lambda invocation"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
node16 is deprecated by github, resulting in deprecation warning when running the action (https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
